### PR TITLE
split NonMappedState

### DIFF
--- a/crates/contract/src/contract/instantiate.rs
+++ b/crates/contract/src/contract/instantiate.rs
@@ -42,35 +42,25 @@ impl Contract<'_> {
             Network::from_str(args.network.as_str()).unwrap_or_else(|e| panic!("{}", e.as_str()));
 
         self.state
-        .non_mapped
-        .save(
-            deps.storage,
-            &NonMappedState {
-                admin: args.admin,
-                network,
-                head_slot: args.head_slot,
-            },
-        )
-        .unwrap();
+            .non_mapped
+            .save(
+                deps.storage,
+                &NonMappedState {
+                    admin: args.admin,
+                    network,
+                    head_slot: args.head_slot,
+                },
+            )
+            .unwrap();
 
         self.state
             .non_mapped_lc
-            .save(
-                deps.storage,
-                &NonMappedStateLC {
-                    vkey_lc_update,
-                },
-            )
-        .unwrap();
+            .save(deps.storage, &NonMappedStateLC { vkey_lc_update })
+            .unwrap();
 
         self.state
             .non_mapped_sc
-            .save(
-                deps.storage,
-                &NonMappedStateSC {
-                    vkey_sc_update,
-                },
-            )
-        .unwrap();
+            .save(deps.storage, &NonMappedStateSC { vkey_sc_update })
+            .unwrap();
     }
 }

--- a/crates/contract/src/contract/instantiate.rs
+++ b/crates/contract/src/contract/instantiate.rs
@@ -1,7 +1,7 @@
 use super::Contract;
 use crate::eth_utility::{compute_sync_committee_period, Network};
 use crate::msg::InitInput;
-use crate::state::NonMappedState;
+use crate::state::{NonMappedState, NonMappedStateLC, NonMappedStateSC};
 use cosmwasm_std::DepsMut;
 use electron_rs::verifier::near::{get_prepared_verifying_key, parse_verification_key};
 use std::str::FromStr;
@@ -42,17 +42,35 @@ impl Contract<'_> {
             Network::from_str(args.network.as_str()).unwrap_or_else(|e| panic!("{}", e.as_str()));
 
         self.state
-            .non_mapped
+        .non_mapped
+        .save(
+            deps.storage,
+            &NonMappedState {
+                admin: args.admin,
+                network,
+                head_slot: args.head_slot,
+            },
+        )
+        .unwrap();
+
+        self.state
+            .non_mapped_lc
             .save(
                 deps.storage,
-                &NonMappedState {
-                    admin: args.admin,
-                    network,
-                    head_slot: args.head_slot,
+                &NonMappedStateLC {
                     vkey_lc_update,
+                },
+            )
+        .unwrap();
+
+        self.state
+            .non_mapped_sc
+            .save(
+                deps.storage,
+                &NonMappedStateSC {
                     vkey_sc_update,
                 },
             )
-            .unwrap();
+        .unwrap();
     }
 }

--- a/crates/contract/src/contract/mod.rs
+++ b/crates/contract/src/contract/mod.rs
@@ -104,8 +104,8 @@ impl Contract<'_> {
 
         let public_inputs = format!("{:?}", vec![hash_and_mask.to_string()]);
 
-        let non_mapped_state = self.state.non_mapped.load(deps.storage).unwrap();
-        let vkey_lc_update = non_mapped_state.vkey_lc_update;
+        let non_mapped_state_lc = self.state.non_mapped_lc.load(deps.storage).unwrap();
+        let vkey_lc_update = non_mapped_state_lc.vkey_lc_update;
 
         assert!(
             verify_proof(
@@ -134,8 +134,8 @@ impl Contract<'_> {
         }
         let public_inputs = format!("{:?}", public_inputs);
 
-        let non_mapped_state = self.state.non_mapped.load(deps.storage).unwrap();
-        let vkey_sc_update = non_mapped_state.vkey_sc_update;
+        let non_mapped_state_sc = self.state.non_mapped_sc.load(deps.storage).unwrap();
+        let vkey_sc_update = non_mapped_state_sc.vkey_sc_update;
 
         assert!(
             verify_proof(vkey_sc_update, sc_update_proof, public_inputs).unwrap(),

--- a/crates/contract/src/state.rs
+++ b/crates/contract/src/state.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 use electron_rs::verifier::near::PreparedVerifyingKey;
 
 const NON_MAPPED_STATE_KEY: &str = "non_mapped";
+const NON_MAPPED_STATE_LC_KEY: &str = "non_mapped_lc";
+const NON_MAPPED_STATE_SC_KEY: &str = "non_mapped_sc";
 const HEADER_ROOTS: &str = "header_roots";
 const EXECUTION_STATE_ROOTS: &str = "execution_state_roots";
 const SYNC_COMMITTEE_POSEIDON_HASHES: &str = "sync_committee_poseidon_hashes";
@@ -16,6 +18,8 @@ pub struct ContractState<'a> {
 
     // state that is not stored in maps
     pub non_mapped: Item<'a, NonMappedState>,
+    pub non_mapped_lc: Item<'a, NonMappedStateLC>,
+    pub non_mapped_sc: Item<'a, NonMappedStateSC>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -25,8 +29,16 @@ pub struct NonMappedState {
     pub network: Network,
     /// Latest head slot
     pub head_slot: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct NonMappedStateLC {
     /// lc_update circuit verification key
     pub vkey_lc_update: PreparedVerifyingKey,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct NonMappedStateSC {
     /// sc_update circuit verification key
     pub vkey_sc_update: PreparedVerifyingKey,
 }
@@ -45,6 +57,8 @@ impl ContractState<'_> {
     pub fn new() -> Self {
         Self {
             non_mapped: Item::new(NON_MAPPED_STATE_KEY),
+            non_mapped_lc: Item::new(NON_MAPPED_STATE_LC_KEY),
+            non_mapped_sc: Item::new(NON_MAPPED_STATE_SC_KEY),
             mapped: MappedState {
                 header_roots: Map::new(HEADER_ROOTS),
                 execution_state_roots: Map::new(EXECUTION_STATE_ROOTS),


### PR DESCRIPTION
Keeping _vkey_lc_update_ and _vkey_sc_update_ fields in a single item exceeds the size limit, so added multiple NonMappedState.